### PR TITLE
Add linker flag to solve build problem with undefined reference

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -10,7 +10,7 @@ SWCPROTO = /usr/share/swc/swc.xml
 
 # includes and libs
 INCS = -I${PIXMANINC}
-LIBS = -lwayland-client -lxkbcommon -lwld
+LIBS = -lwayland-client -lxkbcommon -lwld -lfontconfig
 
 # flags
 CPPFLAGS = -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_XOPEN_SOURCE=700 -D_POSIX_C_SOURCE=200809L -DVERSION=\"${VERSION}\"


### PR DESCRIPTION
`
/usr/bin/ld: drw.o: undefined reference to symbol 'FcPatternDuplicate'
/usr/lib/libfontconfig.so.1: error adding symbols: DSO missing from command line
`